### PR TITLE
[bugfix] fix force-close on refresh after fresh install

### DIFF
--- a/res/values/array.xml
+++ b/res/values/array.xml
@@ -6,8 +6,8 @@
 	    <item name="Kiel">Kiel</item>
 	</string-array>
 	<string-array name="ffstaedteValues">
-	    <item name="Hamburg">http://freifunk-gw01.hamburg.ccc.de/ffhhmap/nodes.json</item>
-		<item name="Lübeck">http://188.138.99.158/mesh/nodes.json</item>    
-		<item name="Kiel">http://freifunk.in-kiel.de/ffmap/nodes.json</item>
+	    <item name="Hamburg">@string/nodes_url_hh</item>
+		<item name="Lübeck">@string/nodes_url_hl</item>
+		<item name="Kiel">@string/nodes_url_ki</item>
 	</string-array>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -10,4 +10,7 @@
 
     <string name="title_activity_preference">Settings</string>
 
+    <string name="nodes_url_hh">http://freifunk-gw01.hamburg.ccc.de/ffhhmap/nodes.json</string>
+    <string name="nodes_url_hl">http://188.138.99.158/mesh/nodes.json</string>
+    <string name="nodes_url_ki">http://freifunk.in-kiel.de/ffmap/nodes.json</string>
 </resources>

--- a/src/de/nijen/freifunknord/FreifunkNord.java
+++ b/src/de/nijen/freifunknord/FreifunkNord.java
@@ -27,7 +27,8 @@ public class FreifunkNord extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState); 
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
-    	url = Uri.parse(sharedPrefs.getString("ffstaedteValues", "http://freifunk-gw01.hamburg.ccc.de/ffhhmap/nodes.json"));
+        String default_url = getString(R.string.nodes_url_hh);
+    	url = Uri.parse(sharedPrefs.getString("ffstaedteValues", default_url));
     	HttpAsyncTask task = new HttpAsyncTask(url.toString(), result, this);
     	task.execute();
     }
@@ -35,7 +36,8 @@ public class FreifunkNord extends Activity {
 
    public void  updateList(){
 	   SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
-   	   url = Uri.parse(sharedPrefs.getString("ffstaedteValues", "null"));
+	   String default_url = getString(R.string.nodes_url_hh);
+	   url = Uri.parse(sharedPrefs.getString("ffstaedteValues", default_url));
   	   HttpAsyncTask task = new HttpAsyncTask(url.toString(), result, this);
   	   task.execute();	 
    }


### PR DESCRIPTION
this was raised by the default string "null" if the shared
preferences not yet contained a value for "ffstaedteValues".
